### PR TITLE
[Kafka][Java-client] Jun/support max fetch size

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -162,12 +162,15 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String REQUEST_TIMEOUT_MS_CONFIG = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
     private static final String REQUEST_TIMEOUT_MS_DOC = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
 
+    /** <code>max.poll.records</code> */
+    public static final String MAX_POLL_RECORDS_CONFIG = "max.poll.records";
+    private static final String MAX_POLL_RECORDS_DOC = "The maximum number of records returned in a single call to poll().";
 
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
-                                        Type.LIST,
-                                        Importance.HIGH,
-                                        CommonClientConfigs.BOOSTRAP_SERVERS_DOC)
+            Type.LIST,
+            Importance.HIGH,
+            CommonClientConfigs.BOOSTRAP_SERVERS_DOC)
                                 .define(GROUP_ID_CONFIG, Type.STRING, "", Importance.HIGH, GROUP_ID_DOC)
                                 .define(SESSION_TIMEOUT_MS_CONFIG,
                                         Type.INT,
@@ -290,7 +293,16 @@ public class ConsumerConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.MEDIUM,
                                         REQUEST_TIMEOUT_MS_DOC)
-                                /* default is set to be a bit lower than the server default (10 min), to avoid both client and server closing connection at same time */
+                                .define(MAX_POLL_RECORDS_CONFIG,
+                                        Type.INT,
+                                        Integer.MAX_VALUE,
+                                        atLeast(1),
+                                        Importance.MEDIUM,
+                                        MAX_POLL_RECORDS_DOC)
+
+                                /* default is set to be a bit lower than the server default (10
+                                min), to avoid both client and server closing connection at same
+                                time */
                                 .define(CONNECTIONS_MAX_IDLE_MS_CONFIG,
                                         Type.LONG,
                                         9 * 60 * 1000,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -625,6 +625,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     config.getInt(ConsumerConfig.FETCH_MIN_BYTES_CONFIG),
                     config.getInt(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG),
                     config.getInt(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG),
+                    config.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG),
                     config.getBoolean(ConsumerConfig.CHECK_CRCS_CONFIG),
                     this.keyDeserializer,
                     this.valueDeserializer,
@@ -860,7 +861,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     // task execution since the consumed positions has already been updated and we
                     // must return these records to users to process before being interrupted or
                     // auto-committing offsets
-                    fetcher.initFetches(metadata.fetch());
+                    fetcher.sendFetches(metadata.fetch());
                     client.quickPoll();
                     return new ConsumerRecords<>(records);
                 }
@@ -904,7 +905,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             return records;
         }
 
-        fetcher.initFetches(cluster);
+        fetcher.sendFetches(cluster);
         client.poll(timeout);
         return fetcher.fetchedRecords();
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +77,7 @@ public class Fetcher<K, V> {
     private final int maxWaitMs;
     private final int fetchSize;
     private final long retryBackoffMs;
+    private final int maxPollRecords;
     private final boolean checkCrcs;
     private final Metadata metadata;
     private final FetchManagerMetrics sensors;
@@ -92,6 +94,7 @@ public class Fetcher<K, V> {
                    int minBytes,
                    int maxWaitMs,
                    int fetchSize,
+                   int maxPollRecords,
                    boolean checkCrcs,
                    Deserializer<K> keyDeserializer,
                    Deserializer<V> valueDeserializer,
@@ -110,6 +113,7 @@ public class Fetcher<K, V> {
         this.minBytes = minBytes;
         this.maxWaitMs = maxWaitMs;
         this.fetchSize = fetchSize;
+        this.maxPollRecords = maxPollRecords;
         this.checkCrcs = checkCrcs;
 
         this.keyDeserializer = keyDeserializer;
@@ -129,7 +133,7 @@ public class Fetcher<K, V> {
      *
      * @param cluster The current cluster metadata
      */
-    public void initFetches(Cluster cluster) {
+    public void sendFetches(Cluster cluster) {
         for (Map.Entry<Node, FetchRequest> fetchEntry: createFetchRequests(cluster).entrySet()) {
             final FetchRequest fetch = fetchEntry.getValue();
             client.send(fetchEntry.getKey(), ApiKeys.FETCH, fetch)
@@ -394,44 +398,58 @@ public class Fetcher<K, V> {
             throwIfUnauthorizedTopics();
             throwIfRecordTooLarge();
 
-            for (PartitionRecords<K, V> part : this.records) {
-                if (!subscriptions.isAssigned(part.partition)) {
-                    // this can happen when a rebalance happened before fetched records are returned to the consumer's poll call
-                    log.debug("Not returning fetched records for partition {} since it is no longer assigned", part.partition);
-                    continue;
-                }
-
-                // note that the consumed position should always be available
-                // as long as the partition is still assigned
-                long position = subscriptions.position(part.partition);
-                if (!subscriptions.isFetchable(part.partition)) {
-                    // this can happen when a partition is paused before fetched records are returned to the consumer's poll call
-                    log.debug("Not returning fetched records for assigned partition {} since it is no longer fetchable", part.partition);
-                } else if (part.fetchOffset == position) {
-                    long nextOffset = part.records.get(part.records.size() - 1).offset() + 1;
-
-                    log.trace("Returning fetched records at offset {} for assigned partition {} and update " +
-                            "position to {}", position, part.partition, nextOffset);
-
-                    List<ConsumerRecord<K, V>> records = drained.get(part.partition);
-                    if (records == null) {
-                        records = part.records;
-                        drained.put(part.partition, records);
-                    } else {
-                        records.addAll(part.records);
-                    }
-
-                    subscriptions.position(part.partition, nextOffset);
-                } else {
-                    // these records aren't next in line based on the last consumed position, ignore them
-                    // they must be from an obsolete request
-                    log.debug("Ignoring fetched records for {} at offset {} since the current position is {}",
-                            part.partition, part.fetchOffset, position);
-                }
+            int maxRecords = maxPollRecords;
+            Iterator<PartitionRecords<K, V>> iterator = records.iterator();
+            while (iterator.hasNext() && maxRecords > 0) {
+                PartitionRecords<K, V> part = iterator.next();
+                maxRecords -= append(drained, part, maxRecords);
+                if (part.isConsumed())
+                    iterator.remove();
             }
-            this.records.clear();
             return drained;
         }
+    }
+
+
+    private int append(Map<TopicPartition, List<ConsumerRecord<K, V>>> drained,
+                       PartitionRecords<K, V> part,
+                       int maxRecords) {
+        if (!subscriptions.isAssigned(part.partition)) {
+            // this can happen when a rebalance happened before fetched records are returned to the consumer's poll call
+            log.debug("Not returning fetched records for partition {} since it is no longer assigned", part.partition);
+        } else {
+            // note that the consumed position should always be available as long as the partition is still assigned
+            long position = subscriptions.position(part.partition);
+            if (!subscriptions.isFetchable(part.partition)) {
+                // this can happen when a partition is paused before fetched records are returned to the consumer's poll call
+                log.debug("Not returning fetched records for assigned partition {} since it is no longer fetchable", part.partition);
+            } else if (part.fetchOffset == position) {
+                List<ConsumerRecord<K, V>> partRecords = part.take(maxRecords);
+                long nextOffset = partRecords.get(partRecords.size() - 1).offset() + 1;
+
+                log.trace("Returning fetched records at offset {} for assigned partition {} and update " +
+                    "position to {}", position, part.partition, nextOffset);
+
+                List<ConsumerRecord<K, V>> records = drained.get(part.partition);
+                if (records == null) {
+                    records = partRecords;
+                    drained.put(part.partition, records);
+                } else {
+                    records.addAll(partRecords);
+                }
+
+                subscriptions.position(part.partition, nextOffset);
+                return partRecords.size();
+            } else {
+                // these records aren't next in line based on the last consumed position, ignore them
+                // they must be from an obsolete request
+                log.debug("Ignoring fetched records for {} at offset {} since the current position is {}",
+                    part.partition, part.fetchOffset, position);
+            }
+        }
+
+        part.discard();
+        return 0;
     }
 
     /**
@@ -442,7 +460,7 @@ public class Fetcher<K, V> {
      * @return A response which can be polled to obtain the corresponding offset.
      */
     private RequestFuture<Long> sendListOffsetRequest(final TopicPartition topicPartition, long timestamp) {
-        Map<TopicPartition, ListOffsetRequest.PartitionData> partitions = new HashMap<TopicPartition, ListOffsetRequest.PartitionData>(1);
+        Map<TopicPartition, ListOffsetRequest.PartitionData> partitions = new HashMap<>(1);
         partitions.put(topicPartition, new ListOffsetRequest.PartitionData(timestamp, 1));
         PartitionInfo info = metadata.fetch().partition(topicPartition);
         if (info == null) {
@@ -495,6 +513,15 @@ public class Fetcher<K, V> {
         }
     }
 
+    private Set<TopicPartition> fetchablePartitions() {
+        Set<TopicPartition> fetchable = subscriptions.fetchablePartitions();
+        if (records.isEmpty())
+            return fetchable;
+        for (PartitionRecords<K, V> partitionRecords : records)
+            fetchable.remove(partitionRecords.partition);
+        return fetchable;
+    }
+
     /**
      * Create fetch requests for all nodes for which we have assigned partitions
      * that have no existing requests in flight.
@@ -502,7 +529,7 @@ public class Fetcher<K, V> {
     private Map<Node, FetchRequest> createFetchRequests(Cluster cluster) {
         // create the fetch info
         Map<Node, Map<TopicPartition, FetchRequest.PartitionData>> fetchable = new HashMap<>();
-        for (TopicPartition partition : subscriptions.fetchablePartitions()) {
+        for (TopicPartition partition : fetchablePartitions()) {
             Node node = cluster.leaderFor(partition);
             if (node == null) {
                 metadata.requestUpdate();
@@ -638,6 +665,37 @@ public class Fetcher<K, V> {
             this.fetchOffset = fetchOffset;
             this.partition = partition;
             this.records = records;
+        }
+
+        private boolean isConsumed() {
+            return records == null || records.isEmpty();
+        }
+
+        private void discard() {
+            this.records = null;
+        }
+
+        private List<ConsumerRecord<K, V>> take(int n) {
+            if (records == null)
+                return Collections.emptyList();
+
+            if (n >= records.size()) {
+                List<ConsumerRecord<K, V>> res = this.records;
+                this.records = null;
+                return res;
+            }
+
+            List<ConsumerRecord<K, V>> res = new ArrayList<>(n);
+            Iterator<ConsumerRecord<K, V>> iterator = records.iterator();
+            for (int i = 0; i < n; i++) {
+                res.add(iterator.next());
+                iterator.remove();
+            }
+
+            if (iterator.hasNext())
+                this.fetchOffset = iterator.next().offset();
+
+            return res;
         }
     }
 

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -289,17 +289,8 @@ abstract class BaseConsumerTest extends IntegrationTestHarness with Logging {
   }
 
   protected def consumeAndVerifyRecords(consumer: Consumer[Array[Byte], Array[Byte]], numRecords: Int, startingOffset: Int,
-                                      startingKeyAndValueIndex: Int = 0, tp: TopicPartition = tp) {
-    val records = new ArrayList[ConsumerRecord[Array[Byte], Array[Byte]]]()
-    val maxIters = numRecords * 300
-    var iters = 0
-    while (records.size < numRecords) {
-      for (record <- consumer.poll(50).asScala)
-        records.add(record)
-      if (iters > maxIters)
-        throw new IllegalStateException("Failed to consume the expected records after " + iters + " iterations.")
-      iters += 1
-    }
+                                      startingKeyAndValueIndex: Int = 0, tp: TopicPartition = tp, maxPollRecords: Int = Int.MaxValue) {
+    val records = consumeRecords(consumer, numRecords, maxPollRecords = maxPollRecords)
     for (i <- 0 until numRecords) {
       val record = records.get(i)
       val offset = startingOffset + i
@@ -311,6 +302,25 @@ abstract class BaseConsumerTest extends IntegrationTestHarness with Logging {
       assertEquals(s"value $keyAndValueIndex", new String(record.value()))
     }
   }
+
+  protected def consumeRecords[K, V](consumer: Consumer[K, V],
+                                     numRecords: Int,
+                                     maxPollRecords: Int = Int.MaxValue): ArrayList[ConsumerRecord[K, V]] = {
+    val records = new ArrayList[ConsumerRecord[K, V]]
+    val maxIters = numRecords * 300
+    var iters = 0
+    while (records.size < numRecords) {
+      val polledRecords = consumer.poll(50).asScala
+      assertTrue(polledRecords.size <= maxPollRecords)
+      for (record <- polledRecords)
+        records.add(record)
+      if (iters > maxIters)
+        throw new IllegalStateException("Failed to consume the expected records after " + iters + " iterations.")
+      iters += 1
+    }
+    records
+  }
+
 
   protected def awaitCommitCallback(consumer: Consumer[Array[Byte], Array[Byte]], commitCallback: CountConsumerCommitCallback): Unit = {
     val startCount = commitCallback.count

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -33,6 +33,21 @@ import JavaConverters._
 class PlaintextConsumerTest extends BaseConsumerTest {
 
   @Test
+  def testMaxPollRecords() {
+    val maxPollRecords = 2
+    val numRecords = 10000
+
+    sendRecords(numRecords)
+
+    this.consumerConfig.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)
+    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
+    consumer0.assign(List(tp).asJava)
+
+    consumeAndVerifyRecords(consumer0, numRecords = numRecords, startingOffset = 0,
+      maxPollRecords = maxPollRecords)
+  }
+
+  @Test
   def testAutoCommitOnClose() {
     this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
     val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 group=org.apache.kafka
-version=0.9.0.1
+version=0.9.0.1.m1
 scalaVersion=2.10.5
 task=build
 org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx1024m -Xss2m


### PR DESCRIPTION
@SonicWang @wmoss  @soumyadip-banerjee

This PR implemented max.poll.records for new consumer (0.9.0.1).
It is a backport of KIP-41.
Please check https://cwiki.apache.org/confluence/display/KAFKA/KIP-41%3A+KafkaConsumer+Max+Records for details.
