### PR TITLE
OOM fix  KAFKA-3933 backport to 0.9.0.1

### DIFF
--- a/core/src/main/scala/kafka/message/ByteBufferMessageSet.scala
+++ b/core/src/main/scala/kafka/message/ByteBufferMessageSet.scala
@@ -67,7 +67,6 @@ object ByteBufferMessageSet {
 
       val inputStream: InputStream = new ByteBufferBackedInputStream(wrapperMessage.payload)
 
-      //val compressed: DataInputStream = new DataInputStream(CompressionFactory(wrapperMessage.compressionCodec, inputStream))
 
       val messageAndOffsets = {
         val compressed = try {


### PR DESCRIPTION
native memory leak.backport the similar idea to 0.9.0.1 as https://github.com/apache/kafka/pull/1660
for 
https://issues.apache.org/jira/browse/KAFKA-3933
@jun-he @alexism @SonicWang 
